### PR TITLE
Change FIELDS from dict to set

### DIFF
--- a/viewsb/decoders/standard_requests.py
+++ b/viewsb/decoders/standard_requests.py
@@ -104,13 +104,13 @@ class GetStatus(StandardControlRequest):
     REQUEST_NUMBER = 0
     REQUEST_NAME = "GET STATUS"
 
-    FIELDS = {}
+    FIELDS = set()
 
     def validate(self):
         self.new_address = self.value
 
     def summarize(self):
-        return "requesting {} status".format(self.recipient.name.tolower())
+        return "requesting {} status".format(self.recipient.name.lower())
 
 
 class SetAddressRequest(StandardControlRequest):


### PR DESCRIPTION
This allows set union (via |=) to occur in other parts of the code base.  Change to correct string method.  

These caused errors on MacOS running Python 3.7.3