### PR TITLE
analyzer/ipc: always use fork start method; fixes crash on macOS

### DIFF
--- a/viewsb/analyzer.py
+++ b/viewsb/analyzer.py
@@ -7,6 +7,7 @@ This file is part of ViewSB
 """
 
 import queue
+import multiprocessing
 
 from .decoder import ViewSBDecoder
 from .decoders import *
@@ -36,6 +37,10 @@ class ViewSBAnalyzer:
                         ViewSB decoders are intended to produce sane results with all filters enabled, so this is likely
                         what you want.
         """
+
+        # The spawn method became the default on macOS in Python 3.8, but that crashes,
+        # so make it use the fork method.
+        multiprocessing.set_start_method('fork')
 
         # If decoders weren't specified, use all decoders.
         if decoders is None:


### PR DESCRIPTION
[As of Python 3.8](https://docs.python.org/3/whatsnew/3.8.html#multiprocessing) the spawn start method is the default on macOS, but we currently don't support it, so ViewSB was crashing on macOS with Python 3.8. We should probably switch to using the spawn method later on (see #44), but this fixes the crash for now.