### PR TITLE
multiprocessing: fix and use spawn start method

### DIFF
--- a/viewsb/analyzer.py
+++ b/viewsb/analyzer.py
@@ -7,6 +7,7 @@ This file is part of ViewSB
 """
 
 import queue
+import multiprocessing
 
 from .decoder import ViewSBDecoder
 from .decoders import *
@@ -36,6 +37,10 @@ class ViewSBAnalyzer:
                         ViewSB decoders are intended to produce sane results with all filters enabled, so this is likely
                         what you want.
         """
+
+        # The fork method is the default for Linux (and macOS prior to Python 3.8), but it's considered unsafe
+        # on macOS, and it isn't available on Windows, so we'll use the spawn method for all platforms.
+        multiprocessing.set_start_method('spawn')
 
         # If decoders weren't specified, use all decoders.
         if decoders is None:

--- a/viewsb/analyzer.py
+++ b/viewsb/analyzer.py
@@ -6,6 +6,7 @@ Decoders, and outputting data to a Frontend (e.g. our main GUI).
 This file is part of ViewSB
 """
 
+import time
 import queue
 import multiprocessing
 
@@ -176,10 +177,6 @@ class ViewSBAnalyzer:
 
     def run(self):
         """ Run this core analysis thread until the frontend requests we stop. Performs the USB analysis itself. """
-
-        # Pass the frontend stdin; this allows console-interactive analyzer to work.
-        # We implicitly give up stdin by calling this.
-        self.frontend.pass_stdin()
 
         # Start our core bg/fg threads.
         self.backend.start()

--- a/viewsb/backend.py
+++ b/viewsb/backend.py
@@ -29,7 +29,7 @@ class ViewSBBackend(ViewSBEnumerableFromUI):
         pass
 
 
-    def set_up_ipc(self, output_queue, termination_event, stdin=None):
+    def set_up_ipc(self, output_queue, termination_event):
         """
         Method that accepts the synchronization objects we'll use for output. Must be called prior to
         calling run(). Usually called by the BackendProcess setup functions.

--- a/viewsb/frontend.py
+++ b/viewsb/frontend.py
@@ -5,8 +5,6 @@ ViewSB frontend class definitions -- defines the abstract base for things that d
 This file is part of ViewSB
 """
 
-import io
-import sys
 import queue
 
 from .ipc import ProcessManager
@@ -144,7 +142,7 @@ class ViewSBFrontend(ViewSBEnumerableFromUI):
         pass
 
 
-    def set_up_ipc(self, data_queue, termination_event, stdin=None):
+    def set_up_ipc(self, data_queue, termination_event):
         """
         Function that accepts the synchronization objects we'll use for input. Must be called prior to
         calling run().
@@ -158,9 +156,9 @@ class ViewSBFrontend(ViewSBEnumerableFromUI):
         self.data_queue        = data_queue
         self.termination_event = termination_event
 
-        # Retrieve our use of the standard input from the parent thread.
-        if stdin:
-            self.stdin = sys.stdin = stdin
+        # Re-open stdin. Note that we don't try to pass stdin between the processes,
+        # as the object isn't picklable, and we spawned a new process instead of forking.
+        self.stdin = open(0)
 
 
 


### PR DESCRIPTION
Closes #44. Supersedes #45.