### PR TITLE
BREAKING CHANGE: rewrite argument parsing

### DIFF
--- a/viewsb/analyzer.py
+++ b/viewsb/analyzer.py
@@ -11,7 +11,9 @@ import queue
 import multiprocessing
 
 from .decoder import ViewSBDecoder
+# pylint: disable=W0401, W0614
 from .decoders import *
+# pylint: enable=W0401, W0614
 
 from .backend import ViewSBBackendProcess
 from .frontend import ViewSBFrontendProcess
@@ -57,11 +59,11 @@ class ViewSBAnalyzer:
 
         # Create -- but don't start -- our backend process.
         backend_class, backend_arguments = backend
-        self.backend = ViewSBBackendProcess(backend_class, *backend_arguments)
+        self.backend = ViewSBBackendProcess(backend_class, **backend_arguments)
 
         # Create -- but don't start -- our frontend process.
         frontend_class, frontend_arguments = frontend
-        self.frontend = ViewSBFrontendProcess(frontend_class, *frontend_arguments)
+        self.frontend = ViewSBFrontendProcess(frontend_class, **frontend_arguments)
 
 
     def add_decoder(self, decoder, *arguments, **kwargs):

--- a/viewsb/backend.py
+++ b/viewsb/backend.py
@@ -26,13 +26,15 @@ class ViewSBBackend(ViewSBEnumerableFromUI):
         Method that initializes the relevant backend. In most cases, this objects won't be instantiated
         directly -- but instead instantiated by the `run_asynchronously` / 'run_backend_asynchronously` helpers.
         """
-        pass
+
+        self.output_queue      = None
+        self.termination_event = None
 
 
     def set_up_ipc(self, output_queue, termination_event):
         """
         Method that accepts the synchronization objects we'll use for output. Must be called prior to
-        calling run(). Usually called by the BackendProcess setup functions.
+        calling run(). Usually called by the BackendProcess/FrontendProcess setup functions.
 
         Args:
             output_queue -- The Queue object that will be fed any USB data generated.
@@ -84,6 +86,8 @@ class FileBackend(ViewSBBackend):
 
     def __init__(self, target_file):
 
+        super().__init__()
+
         # Open the relevant file for reading.
         if isinstance(target_file, io.IOBase):
             self.target_file = target_file
@@ -123,9 +127,3 @@ class FileBackend(ViewSBBackend):
     def handle_data(self, data):
         """ Handle chunks of data read from the relevant file. """
         raise NotImplementedError("subclass must implement handle_data()")
-
-
-
-
-
-

--- a/viewsb/backends/rhododendron.py
+++ b/viewsb/backends/rhododendron.py
@@ -194,6 +194,11 @@ class Rhododendron(ViewSBBackend):
     UI_NAME = "rhododendron"
     UI_DESCRIPTION = "GreatFET Rhododendron capture neighbor"
 
+    SPEEDS = {
+        'high': SPEED_HIGH,
+        'full': SPEED_FULL,
+        'low':  SPEED_LOW,
+    }
 
     @staticmethod
     def reason_to_be_disabled():
@@ -211,35 +216,20 @@ class Rhododendron(ViewSBBackend):
         return None
 
 
-    @staticmethod
-    def speed_from_string(string):
-        speeds = {
-            'high': SPEED_HIGH,
-            'full': SPEED_FULL,
-            'low':  SPEED_LOW,
-        }
+    @classmethod
+    def speed_from_string(cls, string):
 
         try:
-            return speeds[string]
+            return cls.SPEEDS[string]
         except KeyError:
             return None
 
 
     @classmethod
-    def parse_arguments(cls, args, parent_parser=[]):
+    def add_options(cls, parser):
 
-        # Parse user input and try to extract our class options.
-        parser = argparse.ArgumentParser(parents=parent_parser, add_help=False)
-        parser.add_argument('--speed', type=cls.speed_from_string, default='high',
-                help="the speed of the USB data to capture [valid: {high, full, low}]")
-        args, leftover_args = parser.parse_known_args()
-
-        if args.speed is None:
-            sys.stderr.write("speed must be 'high', 'full', or 'low'\n")
-            sys.exit(errno.EINVAL)
-
-        #  Return the class and leftover arguments.
-        return (args.speed, ), leftover_args
+        parser.add_argument('--speed', dest='capture_speed', default='high', choices=cls.SPEEDS.keys(),
+            help="The speed of the USB data to capture.")
 
 
     def __init__(self, capture_speed, suppress_packet_callback=None):

--- a/viewsb/backends/usbmon.py
+++ b/viewsb/backends/usbmon.py
@@ -391,17 +391,11 @@ class USBMonFileBackend(USBMonBackend, FileBackend):
 
 
     @staticmethod
-    def parse_arguments(args, parent_parser=[]):
+    def add_options(parser):
 
         # Parse user input and try to extract our class options.
-        parser = argparse.ArgumentParser(parents=parent_parser, add_help=False)
-        parser.add_argument('--file', type=argparse.FileType('rb', bufsize=-0),
+        parser.add_argument('--file', dest='filename', type=argparse.FileType('rb', bufsize=-0),
                 default='/dev/usbmon0', help="the file to read usbmon data from")
-        args, leftover_args = parser.parse_known_args()
-
-        #  Return the class and leftover arguments.
-        return (args.file, ), leftover_args
-
 
 
     # TODO: support modes other than compatibility mode?

--- a/viewsb/backends/usbproxy.py
+++ b/viewsb/backends/usbproxy.py
@@ -261,6 +261,18 @@ class USBProxyBackend(ViewSBBackend):
         self.proxy.connect()
 
 
+    @classmethod
+    def add_options(cls, parser):
+
+        def hex_int(i):
+            return int(i, 16)
+
+        parser.add_argument('-v', '--vid', type=hex_int, required=True, dest='vendor_id',
+            help="USB Vendor ID in hex")
+        parser.add_argument('-p', '--pid', type=hex_int, required=True, dest='product_id',
+            help="USB Product ID in hex")
+
+
     def get_microseconds(self):
 
         # Get the current time...

--- a/viewsb/commands/viewsb.py
+++ b/viewsb/commands/viewsb.py
@@ -7,33 +7,28 @@ This file is part of ViewSB
 """
 
 import sys
-import errno
 import argparse
 
 from .. import ViewSBAnalyzer
 
 from ..packet import USBPacketID
 
-from ..frontends.cli import CLIFrontend
-from ..frontends.tui import TUIFrontend
-
 # Import all of our backends, frontends, and decoders.
 from ..backend import ViewSBBackend
-from ..backends import *
-
 from ..frontend import ViewSBFrontend
+
+# Yes pylint, we know wildcard imports are bad practice, but it's actually necessary in this case because
+# __subclasses__() only returns subclasses that have been imported.
+# pylint: disable=W0401, W0614
+from ..backends import *
 from ..frontends import *
+# pylint: enable=W0401, W0614
 
 from ..decoders.filters import USBStartOfFrameFilter
 
 
-# For current test sanity, suppress SOF packets.
-def suppress_packet(packet):
-    return packet.pid == USBPacketID.SOF
-
-
-def list_enumerables(enumerable_type, name, include_unavailable=True, quit_after=True):
-    """ Prints a list of all availale (and optionally unavailable) backends. """
+def list_enumerables(enumerable_type, name, include_unavailable=True):
+    """ Prints a list of all available (and optionally unavailable) backends. """
 
     # Print the available backends...
     print("Available {}:".format(name))
@@ -51,70 +46,154 @@ def list_enumerables(enumerable_type, name, include_unavailable=True, quit_after
             print("\t{:12} -- {}".format(backend.UI_NAME, reason))
         print()
 
-    if quit_after:
-        sys.exit(0)
+
+class ViewSBArgumentParser(argparse.ArgumentParser):
+    """ Subclass of argparse.ArgumentParser that also stores a list of the argument names as self.arg_names.
+
+    This is desirable because later I want to separate and group the subparser arguments.
+    """
+
+    def __init__(self, *args, **kwargs):
+
+        self.arg_names = []
+
+        super().__init__(*args, **kwargs)
 
 
-def error(message):
-    """ Convenience method to print a message to the stderr. """
-    sys.stderr.write("{}\n".format(message))
-    sys.stderr.flush()
+    def add_argument(self, *args, **kwargs):
+        """ Overrides ArgumentParser.add_argument()
+
+        This performs all the normal functionality, but also stores the argument's name (`dest`) for later.
+        """
+
+        ret = super().add_argument(*args, **kwargs)
+
+        # 'help' won't be in a Namespace object if it's not passed, so we don't really care about it.
+        if ret.dest != 'help':
+            self.arg_names.append(ret.dest)
+
+        return ret
 
 
-def fatal(message, return_code=errno.EINVAL):
-    """ Convenience method to print a message to the stderr. """
-    error(message)
-    sys.exit(return_code)
+    def subparser_by_name(self, name):
+        """ Convenience function that gets a subparser by name.
+
+        Args:
+            name -- The name of the subparser to return. This is the name passed to add_parser(), NOT
+                the name passed to add.subparsers().
+        """
+
+        # Get the subparser action.
+        # As far as I can tell, there can only ever be one of these,
+        # because calling add_subparsers() more than once on the same parser errors.
+        try:
+            subparser_action = \
+                next(action for action in self._subparsers._group_actions if action.nargs == argparse.PARSER)
+        except StopIteration as e:
+            raise KeyError('This parser does not have any subparsers.')
+
+        return subparser_action.choices[name]
 
 
 def main():
     """ Main file runner for ViewSB. """
 
     # Add the common arguments for the runner application.
-    parser = argparse.ArgumentParser(description="open-source USB protocol analyzer")
+    parser = ViewSBArgumentParser(description="open-source USB protocol analyzer")
+    parser.arg_names = []
 
-    # General commands.
-    parser.add_argument('backend', type=ViewSBBackend.get_subclass_from_name, nargs='?',
-            help='the backend to use as a packet source')
-    parser.add_argument('frontend', type=ViewSBFrontend.get_subclass_from_name, nargs='?',
-            help='the frontend to use to display/save packets [default: tui]')
+    parser.arg_names.append(parser.add_argument('--include-sofs', '-S', action='store_true',
+        help="Include USB start-of-frame-markers in the capture; adds a lot of load & noise.").dest)
+    parser.arg_names.append(parser.add_argument('--list-frontends', action='store_true',
+        help='List the available capture backends, then quit.').dest)
+    parser.arg_names.append(parser.add_argument('--list-backends', action='store_true',
+        help='List the available UI frontends, then quit.').dest)
 
-    # Flags.
-    parser.add_argument('--list-backends', action='store_true',
-            help="list the available capture backends, then quit")
-    parser.add_argument('--list-frontends', action='store_true',
-            help="list the available UI frontends, then quit")
-    parser.add_argument('--include-sofs', '-S', action='store_true',
-            help="include USB start-of-frame markers in the capture; adds a load of load & noise")
 
-    # Parse our known arguments.
-    args, leftover_args = parser.parse_known_args()
+    #
+    # Add backends.
+    #
+
+    backend_parsers = parser.add_subparsers(dest='backend', metavar='backend', required=False,
+        help='The capture backend to use.')
+    for backend in ViewSBBackend.available_subclasses():
+
+        # Create a subparser for each backend...
+        parser_for_backend = backend_parsers.add_parser(backend.UI_NAME)
+
+        # ...and add its respective options (if any).
+        backend.add_options(parser_for_backend)
+
+
+        #
+        # Add frontends.
+        #
+
+        # HACK: This is truly terrible, but it seems
+        # this is argparse's only way to make nested 'subcommands'.
+
+        frontend_parsers = parser_for_backend.add_subparsers(dest='frontend',
+            metavar='frontend', required=False, help='The UI frontend to use.')
+
+        for frontend in ViewSBFrontend.available_subclasses():
+
+            # Create a sub-subparser for each available frontend...
+            parser_for_frontend = frontend_parsers.add_parser(frontend.UI_NAME)
+
+            # ...and add its respective options (if any).
+            frontend.add_options(parser_for_frontend)
+
+
+    # HACK: This is a 'fake' argument that makes the help text look right if you pass --help without a backend,
+    # since 'frontend' is an argument that is handled by each backend subparser.
+    parser.add_argument('_frontend', help='The UI frontend to use.', nargs='?', metavar='frontend')
+
+
+    args = parser.parse_args()
+
 
     if args.list_backends:
-        list_enumerables(ViewSBBackend, 'backends', quit_after=not args.list_frontends)
+        list_enumerables(ViewSBBackend, 'backends')
+
+        if not args.list_frontends:
+            sys.exit(0)
+
     if args.list_frontends:
         list_enumerables(ViewSBFrontend, 'frontends')
+        sys.exit(0)
 
-    # Check for the validity of our arguments.
-    if args.backend is None:
-        fatal("invalid backend; use --list-backends for a list of valid backends")
+    if not args.backend:
+
+        # Emulate the argparse error message and exit code.
+        # Note that we don't set required=True for backend because we want the user to be able to
+        # --list-backends without specifying a backend.
+        parser.error('{}: error: the following arguments are required: backend'.format(parser.prog))
+
     if not args.frontend:
-        args.frontend = TUIFrontend
+        args.frontend = 'tui'
 
-    backend_args, leftover_args  = args.backend.parse_arguments(leftover_args, [parser])
-    frontend_args, leftover_args = args.frontend.parse_arguments(leftover_args, [parser])
+    # print(args)
+    args_dict = vars(args)
 
-    # Instantiate the backend and frontend objects.
-    backend  = (args.backend, backend_args)
-    frontend = (args.frontend, frontend_args)
+    # Separate the groups arguments so we can pass them where they belong.
 
-    if leftover_args:
-        fatal("unexpected arguments: {}".format(' '.join(leftover_args)))
+    backend_subparser = parser.subparser_by_name(args.backend)
+    backend_args = {key: args_dict[key] for key in args_dict.keys() & backend_subparser.arg_names}
+
+    frontend_subparser = backend_subparser.subparser_by_name(args.frontend)
+    frontend_args = {key: args_dict[key] for key in args_dict.keys() & frontend_subparser.arg_names}
+
+    backend_class = ViewSBBackend.get_subclass_from_name(args.backend)
+    backend = (backend_class, backend_args)
+
+
+    frontend_class  = ViewSBFrontend.get_subclass_from_name(args.frontend)
+    frontend = (frontend_class, frontend_args)
 
     # Create our analyzer object.
     analyzer = ViewSBAnalyzer(backend, frontend)
 
-    # Unless we're including SOFs, instantiate a SOF filter to filter them out.
+    # Unless we're including SOFs, filter them out.
     if not args.include_sofs:
         analyzer.add_decoder(USBStartOfFrameFilter, to_front=True)
 

--- a/viewsb/frontends/qt.py
+++ b/viewsb/frontends/qt.py
@@ -14,6 +14,7 @@ from ..frontend import ViewSBFrontend
 
 
 try:
+    import PySide2
     from PySide2 import QtCore, QtWidgets
     from PySide2.QtWidgets import QApplication, QMainWindow
     from PySide2.QtWidgets import QTreeWidget, QTreeWidgetItem, QTableView, QAbstractItemView
@@ -369,9 +370,10 @@ class QtFrontend(ViewSBFrontend):
 
     @staticmethod
     def reason_to_be_disabled():
-        # If we weren't able to import PySide2, disable this frontend.
-        if 'QWidget' not in globals():
-            return "PySide2 (Qt library) not available"
+        try:
+            import PySide2
+        except ImportError:
+            return "PySide2 (Qt library) not available."
 
         return None
 

--- a/viewsb/ipc.py
+++ b/viewsb/ipc.py
@@ -15,7 +15,7 @@ class ProcessManager:
     Subclasses are used by the analyzer thread to spawn Frontend and Backend processes.
     """
 
-    def __init__(self, remote_class, *remote_arguments):
+    def __init__(self, remote_class, **remote_arguments):
 
         # Create our output queue and our termination-signaling event.
         self.data_queue        = multiprocessing.Queue()
@@ -82,7 +82,7 @@ class ProcessManager:
         """
 
         # Create a new instance of the task class.
-        task = remote_class(*arguments)
+        task = remote_class(**arguments)
 
         # Pass the new 'task' our IPC mechanisms, and then standard input.
         task.set_up_ipc(data_queue, termination_event)


### PR DESCRIPTION
This overhauls the argument parsing, both how it looks on the command line side and how backends and frontends implement options.

On the command-line side, options specific to a backend are now passed directly after the backend argument and before the frontend argument, and options specific to a frontend are likewise now passed directly after the frontend argument, whereas before all backend and frontend specific options had to be specified at the very end. Also, before this change, backend and frontend specific arguments were not listed in `--help`, whereas now they are (if `--help` is passed after the relevant backend or frontend argument). For example `./viewsb.sh luna qt --speed full` now becomes `./viewsb.sh luna --speed full qt`. Likewise, to list options specific to the LUNA backend: `./viewsb.sh luna --help`.

On the Python code side, previously, backend and frontend classes could define a `parse_arguments()` method that would create a new parser and parse those arguments *after* the initial parsing had begun (which meant that backend or frontend specific options wouldn't show up in `--help`). Now, backend and frontend classes can define an `add_options()` method that takes an already created parser to call `add_argument()` on, and the `__init__()` of that backend or frontend class *must* accept a keyword argument for each option added in `add_options()` (specifically, the name of the keyword argument must match the `dest` value of that option). See the documentation of `ViewSBEnumerableFromUI.add_options()` for more details.