### PR TITLE
backend/FileBackend: open files via the built-in open

### DIFF
--- a/viewsb/backend.py
+++ b/viewsb/backend.py
@@ -7,6 +7,7 @@ This file is part of ViewSB
 
 import io
 import argparse
+import sys
 
 from .ipc import ProcessManager
 from .frontend import ViewSBEnumerableFromUI
@@ -96,7 +97,7 @@ class FileBackend(ViewSBBackend):
             # We delayed opening the file until after the creation of this backend process.
             # But now that we do want to open the file, we want to use the same logic
             # that argparse normally provides.
-            self.target_file = argparse.FileType('rb', bufsize=0)(target_file)
+            self.target_file = open(target_file if target_file != '-' else sys.stdin, 'rb', buffering=0)
 
 
     def next_read_size(self):


### PR DESCRIPTION
This prevents exception stacking. This is a slightly weird use of
FileType, we are not passing an empty unitialized FileType to a parser,
we are creating a FileType and then initializing it right away. That is
essentially the same as opening the file directly, so let's just do
that and prevent exception stacking :)

Signed-off-by: Filipe Laíns <lains@archlinux.org>