### PR TITLE
setup.py: remove unecessary data instalation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
     long_description='python-based USB Analyzer toolkit (and USB analyzer)', # FIXME
     packages=find_packages(),
     include_package_data=True,
-    data_files=[('viewsb/frontends', ['viewsb/frontends/qt.ui'])],
     platforms='any',
     classifiers = [
         'Programming Language :: Python',


### PR DESCRIPTION
setuptools' data_files option is meant to install files to the package
data directory, not to make sure they are included, that should happen
by default if the module they are in is being installed.

Files installed this way can be accessed with pkg_resources, or derived
from importlib.metadata. But we do not do this, we access the file as
relative to __file__.


Furthermore, data_files seems to be deprecated. The official
documentation says it does not works with wheels but it looks like it
does here ¯\_(ツ)_/¯

Signed-off-by: Filipe Laíns <lains@archlinux.org>