### PR TITLE
frontends.tui: fix disappearing focus of first/last packet

### DIFF
--- a/viewsb/frontends/tui.py
+++ b/viewsb/frontends/tui.py
@@ -343,7 +343,7 @@ class PacketListBox(urwid.TreeListBox):
             self.focus_changed_callback(focused_node, focused_node.get_value())
 
         # If we had a previously focused node, let it know it's no longer focused.
-        if self.last_focus:
+        if self.last_focus and self.last_focus != focused_node:
             self.last_focus.rerender_with_focus(False)
 
         # And update our previously-focused-node.


### PR DESCRIPTION
This was driving me nuts since probably the first 5 seconds I've been using ViewSB.

There's actually a related issue where repeatedly pressing left or right does something sketchy, but it's less annoying and also requires a lot more digging into urwid, so I left that one alone for now.