### PR TITLE
Descriptor handling robustness improvements

### DIFF
--- a/viewsb/decoders/standard_descriptors.py
+++ b/viewsb/decoders/standard_descriptors.py
@@ -167,7 +167,7 @@ class GetConfigurationDescriptorRequest(GetDescriptorRequest):
             # FIXME: describe the type of interfaces?
             # FIXME: provide subordinate descriptor count
             return "{} interface(s)".format(decoded['bNumInterfaces'])
-        except KeyError:
+        except (KeyError, TypeError):
             return super().summarize_data()
 
 

--- a/viewsb/descriptor.py
+++ b/viewsb/descriptor.py
@@ -168,6 +168,7 @@ class DescriptorTransfer(ViewSBPacket):
 
         # While we are still getting descriptors, try to handle any left-over data.
         while table_or_string:
+            from construct import ValidationError
 
             # Keep track of our position in the subordinate array.
             subordinate_number = len(self.subordinates)
@@ -175,9 +176,12 @@ class DescriptorTransfer(ViewSBPacket):
             # Clip off any data parsed.
             data = data[bytes_parsed:]
 
-            # Call our "data remaining" callback.
-            description, table_or_string, raw, bytes_parsed = \
-                self.handle_data_remaining_after_decode(data, subordinate_number)
+            try:
+                # Call our "data remaining" callback.
+                description, table_or_string, raw, bytes_parsed = \
+                    self.handle_data_remaining_after_decode(data, subordinate_number)
+            except ValidationError:
+                break
 
             #If we were able to parse more from the remaining data, return it.
             if table_or_string:


### PR DESCRIPTION
Having experienced a couple of crashes on malformed descriptors during the test and debug of [SPIFlashProgrammer](https://github.com/bad-alloc-heavy-industries/SPIFlashProgrammer), I set about improving the robustness of ViewSB's handling to reduce the severity from insta-quit to 'doesn't decode'.

There are undoubtedly more improvements that can be made in this manner, but these were the main two that improved stability for me most.