### PR TITLE
decoders/grouping: fix timedelta comparison

### DIFF
--- a/viewsb/decoders/grouping.py
+++ b/viewsb/decoders/grouping.py
@@ -439,7 +439,7 @@ class USBTransferGrouper(ViewSBDecoder):
 
         # For non-control endpoints, if more than 10 milliseconds have passed since the last packet,
         # heuristically start a new transfer.
-        if packet.endpoint_number != 0 and (packet.timestamp - last_packet.timestamp) > 10e3:
+        if packet.endpoint_number != 0 and (packet.timestamp - last_packet.timestamp).microseconds > 10e3:
             return True
 
 


### PR DESCRIPTION
datetime.timedelta cannot be directly compared to a int/float, even if
it was, it would have to evaluate as microseconds for this code to
work. Currently, we get the following error, we need to extract the
microseconds to perform the comparison.

```
Traceback (most recent call last):
  File "/usr/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/anubis/git/ViewSB/viewsb/commands/viewsb.py", line 206, in <module>
    main()
  File "/home/anubis/git/ViewSB/viewsb/commands/viewsb.py", line 201, in main
    analyzer.run()
  File "/home/anubis/git/ViewSB/viewsb/analyzer.py", line 209, in run
    self.run_analysis_iteration()
  File "/home/anubis/git/ViewSB/viewsb/analyzer.py", line 178, in run_analysis_iteration
    self.process_analysis_queue()
  File "/home/anubis/git/ViewSB/viewsb/analyzer.py", line 124, in process_analysis_queue
    handled = decoder.handle_packet(packet)
  File "/home/anubis/git/ViewSB/viewsb/decoder.py", line 83, in handle_packet
    self.consume_packet(packet)
  File "/home/anubis/git/ViewSB/viewsb/decoders/grouping.py", line 456, in consume_packet
    if self.packet_starts_new_transfer(packet) or self.packet_seems_discontinuous(packet):
  File "/home/anubis/git/ViewSB/viewsb/decoders/grouping.py", line 442, in packet_seems_discontinuous
    if packet.endpoint_number != 0 and (packet.timestamp - last_packet.timestamp) > 10e3:
TypeError: '>' not supported between instances of 'datetime.timedelta' and 'float'
```

Signed-off-by: Filipe Laíns <lains@riseup.net>