### PR TITLE
ipc/analyzer: let backends signal when they are ready

### DIFF
--- a/viewsb/analyzer.py
+++ b/viewsb/analyzer.py
@@ -61,10 +61,16 @@ class ViewSBAnalyzer:
         self._pipe_send_backend_exception, self._pipe_recv_backend_exception = multiprocessing.Pipe()
         self._pipe_send_frontend_exception, self._pipe_recv_frontend_exception = multiprocessing.Pipe()
 
+        # Create backend ready ipc variables
+        self._backend_setup_queue = multiprocessing.Queue()
+        self._backend_ready = multiprocessing.Event()
+
         # Create -- but don't start -- our backend process.
         backend_class, backend_arguments = backend
         self.backend = ViewSBBackendProcess(
             backend_class,
+            self._backend_setup_queue,
+            self._backend_ready,
             self._pipe_send_backend_exception,
             None,
             **backend_arguments,
@@ -74,6 +80,8 @@ class ViewSBAnalyzer:
         frontend_class, frontend_arguments = frontend
         self.frontend = ViewSBFrontendProcess(
             frontend_class,
+            self._backend_setup_queue,
+            self._backend_ready,
             self._pipe_send_frontend_exception,
             self._pipe_recv_backend_exception,  # The frontend manages backend exceptions
             **frontend_arguments,

--- a/viewsb/backends/luna.py
+++ b/viewsb/backends/luna.py
@@ -72,7 +72,10 @@ class LUNABackend(ViewSBBackend):
         # Set up our connection to the analyzer.
         self.analyzer = USBAnalyzerConnection()
 
+
+    def setup(self):
         # Build our analyzer gateware, and configure our FPGA.
+        self.setup_queue.put('Configuring the hardware...')
         self.analyzer.build_and_configure(self.capture_speed)
 
 

--- a/viewsb/frontend.py
+++ b/viewsb/frontend.py
@@ -5,6 +5,7 @@ ViewSB frontend class definitions -- defines the abstract base for things that d
 This file is part of ViewSB
 """
 
+import sys
 import queue
 
 from .ipc import ProcessManager
@@ -275,6 +276,7 @@ class ViewSBFrontend(ViewSBEnumerableFromUI):
 
     def handle_exception(self, exception, traceback):
         print(traceback, end='')
+        sys.exit()
 
 
     def handle_termination(self):

--- a/viewsb/frontend.py
+++ b/viewsb/frontend.py
@@ -146,26 +146,32 @@ class ViewSBFrontend(ViewSBEnumerableFromUI):
         directly -- but instead instantiated by the `run_asynchronously` / 'run_frontend_asynchronously` helpers.
         """
 
-        self.data_queue        = None
-        self.termination_event = None
-        self._exception_conn   = None
-        self.stdin             = None
+        self.data_queue          = None
+        self.backend_setup_queue = None
+        self.backend_ready       = None
+        self.termination_event   = None
+        self._exception_conn     = None
+        self.stdin               = None
 
 
-    def set_up_ipc(self, data_queue, termination_event, exception_conn):
+    def set_up_ipc(self, data_queue, backend_setup_queue, backend_ready, termination_event, exception_conn):
         """
         Function that accepts the synchronization objects we'll use for input. Must be called prior to
         calling run().
 
         Args:
             data_queue -- The Queue object that will feed up analyzed packets for display.
+            backend_setup_queue -- The Queue object that will feed the backend setup message log.
+            backend_ready -- A synchronization event that is set when the backend is ready to emit packets.
             termination_event -- A synchronization event that is set when a capture is terminated.
         """
 
         # Store our IPC primitives, ready for future use.
-        self.data_queue        = data_queue
-        self.termination_event = termination_event
-        self._exception_conn   = exception_conn
+        self.data_queue          = data_queue
+        self.backend_setup_queue = backend_setup_queue
+        self.backend_ready       = backend_ready
+        self.termination_event   = termination_event
+        self._exception_conn     = exception_conn
 
         # Re-open stdin. Note that we don't try to pass stdin between the processes,
         # as the object isn't picklable, and we spawned a new process instead of forking.
@@ -227,8 +233,24 @@ class ViewSBFrontend(ViewSBEnumerableFromUI):
             self.handle_incoming_packet(packet)
 
 
+    def wait_for_backend_ready(self):
+        ''' Wait for backend to be ready and update message log. '''
+        while not self.backend_ready.is_set():
+            try:
+                # add a little timeout when fetching from the queue instead of nonblock to prevent pinning the CPU usage
+                setup_message = self.backend_setup_queue.get(timeout=0.01)
+                self.handle_setup_message(setup_message)
+            except queue.Empty:
+                pass
+            if self._exception_conn.poll():
+                self.handle_exception(*self._exception_conn.recv())
+        self.ready()
+
+
     def run(self):
         """ Runs the given frontend until either side requests termination. """
+
+        self.wait_for_backend_ready()
 
         # Capture infinitely until our termination signal is set.
         while not self.termination_event.is_set():
@@ -240,6 +262,15 @@ class ViewSBFrontend(ViewSBEnumerableFromUI):
 
         # Allow the subclass to handle any cleanup it needs to do.
         self.handle_termination()
+
+
+    def ready(self):
+        """ Called when the backend is ready to stream. """
+
+
+    def handle_setup_message(self, setup_message):
+        """ Called when we get a setup message from the backend. """
+        print(setup_message)
 
 
     def handle_exception(self, exception, traceback):

--- a/viewsb/frontends/qt.py
+++ b/viewsb/frontends/qt.py
@@ -482,6 +482,9 @@ class QtFrontend(ViewSBFrontend):
         self.window.usb_tree_widget = self.window.usb_tree_widget
         self.window.usb_tree_widget.sortByColumn(0, Qt.SortOrder.AscendingOrder)
 
+
+    def ready(self):
+        """ Called when the backend is ready to stream. """
         self.window.showMaximized()
 
 

--- a/viewsb/frontends/qt.py
+++ b/viewsb/frontends/qt.py
@@ -604,6 +604,8 @@ class QtFrontend(ViewSBFrontend):
     def run(self):
         """ Overrides ViewSBFrontend.run(). """
 
+        self.wait_for_backend_ready()
+
         # TODO: is there a better value than 100 ms? Should it be configurable by the Analyzer?
         self.window.update_timer.start(100)
         self.app.exec_()


### PR DESCRIPTION
Currently, frontends such as the Qt one will be shown before the backend
is ready and we won't have any information about what is hapenning. We
just have to wait until data shows up, and since we have backends such
as Luna, that take a while to get setup, this is not a great UX.

This patch adds two things, 1) a way for the backend to signal when it
is ready, and 2) a way for backends to send setup messages to the
frontend, so that we can tell the users what is hapenning (eg. building
gateware, waiting for device to show up, etc.)

It also adds a few callbacks in ViewSBFrontend to interact with the
added interfaces. The default implementation will print setup messages
to stdout.

Signed-off-by: Filipe Laíns <lains@riseup.net>