### PR TITLE
decoders: Only detect short packet is they are ACK'd

### DIFF
--- a/viewsb/decoders/grouping.py
+++ b/viewsb/decoders/grouping.py
@@ -413,7 +413,7 @@ class USBTransferGrouper(ViewSBDecoder):
         # To know if we have a short packet, we need the maximum packet size of the endpoint.
         # Since we don't have that right now, just check if the size is not a multiple of any
         # of the maximum packet sizes.
-        if packet.data is not None:
+        if (packet.data is not None) and (packet.handshake == USBPacketID.ACK):
             if len(packet.data) == 0 or (len(packet.data) % 8) != 0:
                 return True
 


### PR DESCRIPTION
Previously a NAK of a ZLP would still be considered the end,
which is just obviously not the truth, at some point there
should be a ACK (or an error condition)

Fixes #8 again

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>