### PR TITLE
views: Use 'handshake' instead of 'pid' to know status_transfer result

### DIFF
--- a/viewsb/packet.py
+++ b/viewsb/packet.py
@@ -780,7 +780,7 @@ class USBControlTransfer(USBTransfer):
 
         # Set the transfer to stalled if the handshake token is stalled.
         fields['stalled'] = \
-            (status_transfer and status_transfer.pid == USBPacketID.STALL) or \
+            (status_transfer and status_transfer.handshake == USBPacketID.STALL) or \
             (data_transfer and data_transfer.handshake == USBPacketID.STALL)
 
         # Set our subordinate packets to the three packets we're consuming.


### PR DESCRIPTION
Proposed fix for #76
 
Seems to work for me but the logic should be checked by someone that's more familiar with the intended meaning of each field and if this makes sense.