### PR TITLE
backends: add backend for reading pcap files

### DIFF
--- a/viewsb/backends/pcap.py
+++ b/viewsb/backends/pcap.py
@@ -1,0 +1,117 @@
+#
+# This file is part of ViewSB.
+#
+""" Work in progress backend for PCAP files. """
+
+# pylint: disable=maybe-no-member,access-member-before-definition
+
+
+from datetime import timedelta
+
+from time import sleep
+
+from ..backend import ViewSBBackend
+from ..packet import USBPacket
+
+try:
+    # https://github.com/kisom/pypcapfile
+    from pcapfile import savefile 
+
+except (ImportError, ModuleNotFoundError):
+    pass
+
+
+class PcapBackend(ViewSBBackend):
+    """ Capture backend that reads packets from a pcap file. """
+
+    UI_NAME = "pcap"
+    UI_DESCRIPTION = "pcap file reader"
+
+
+    @staticmethod
+    def reason_to_be_disabled():
+
+        # If we can't import the savefile from pcapfile library, it's probably not installed.
+        if not 'savefile' in globals():
+            return "python pcapfile package not available"
+
+        return None
+
+
+    @classmethod
+    def add_options(cls, parser):
+
+        # Parse user input and try to extract our class options.
+        parser.add_argument('--filename', dest='filename', default='', required=True,
+            help="The pcap file to read from")
+
+
+    def __init__(self, filename, suppress_packet_callback=None):
+        """ Creates a new pcap file reader backend.
+
+        Args:
+            filename -- pcap file to read from.
+        """
+
+        super().__init__()
+
+        self.filenane = filename
+        self.pcapfile = None
+
+        # Store the callback we use to determine if we should suppress packets.
+        self.suppress_packet_callback = suppress_packet_callback
+
+    def _should_be_suppressed(self, packet):
+        """ Returns true iff the given packet should be suppressed, e.g. because of a user-provided condition. """
+
+        if callable(self.suppress_packet_callback):
+            return self.suppress_packet_callback(packet)
+        else:
+            return False
+
+
+
+    def setup(self):
+        self.setup_queue.put('Opening file ' + self.filenane +' ...')
+        
+        self.pcapfile = open(self.filenane, 'rb')
+        self.pcapdata = savefile.load_savefile(self.pcapfile,verbose=False)
+
+        self.packet_index = 0
+        self.packet_count = len(self.pcapdata.packets)
+
+
+    def run_capture(self):
+
+        # while not yet at the end of the file keep pulling packets....
+        if (self.packet_index < self.packet_count):
+
+            # read a single packet from pcap file.
+            pkt = self.pcapdata.packets[self.packet_index]
+            raw_packet = bytearray(pkt.raw())
+
+            # openvizsla pcap files use nanosecond resolution format; ViewSB expects microseconds
+            if (self.pcapdata.header.ns_resolution):                
+                us = pkt.timestamp_us/1000
+            else:
+                us = pkt.timestamp_us
+
+            #print (self.packet_index, ts, raw_packet)
+
+            self.packet_index = self.packet_index + 1
+
+            # TODO: handle flags
+            packet = USBPacket.from_raw_packet(
+                raw_packet,
+                timestamp=timedelta(microseconds=us),
+            )
+            # Assume the packet isn't one we're suppressing, emit it to our stack.
+            if not self._should_be_suppressed(packet):
+                self.emit_packet(packet)
+        else:
+            # FIXME - nothing to do anymore; stay idle -- should be some way to indicate the gui process to stop capturing
+            if (self.pcapfile):
+                self.pcapfile.close()
+                self.pcapfile = None
+                self.pcapdata = None
+            sleep(5)

--- a/viewsb/backends/pcap.py
+++ b/viewsb/backends/pcap.py
@@ -14,6 +14,7 @@ from ..backend import ViewSBBackend
 from ..packet import USBPacket
 
 try:
+    # https://pypi.org/project/pypcapfile/
     # https://github.com/kisom/pypcapfile
     from pcapfile import savefile 
 
@@ -70,7 +71,6 @@ class PcapBackend(ViewSBBackend):
             return False
 
 
-
     def setup(self):
         self.setup_queue.put('Opening file ' + self.filenane +' ...')
         
@@ -95,8 +95,6 @@ class PcapBackend(ViewSBBackend):
                 us = pkt.timestamp_us/1000
             else:
                 us = pkt.timestamp_us
-
-            #print (self.packet_index, ts, raw_packet)
 
             self.packet_index = self.packet_index + 1
 


### PR DESCRIPTION
This pull request adds a backend to read data from pcap files; as written by the Openvizsla ovctl utility. 

Using captured traces allows for protocol analysis without the need to re-capture the events from the hardware device over and over again. 

Note that this backend can be regarded as a temporary/interim solution until ViewSB gets a feature to save/load captured data (discussed in #10)