### PR TITLE
frontends/qt: add packet sequence number to the visualization

### DIFF
--- a/viewsb/backend.py
+++ b/viewsb/backend.py
@@ -33,6 +33,8 @@ class ViewSBBackend(ViewSBEnumerableFromUI):
         self.ready             = None
         self.termination_event = None
 
+        self.packet_sequence = 1
+
 
     def set_up_ipc(self, output_queue, setup_queue, ready, termination_event, exception_conn):
         """
@@ -64,6 +66,10 @@ class ViewSBBackend(ViewSBEnumerableFromUI):
 
     def emit_packet(self, packet):
         """ Emits a given ViewSBPacket-derivative to the main decoder thread for analysis. """
+
+        packet.sequence = self.packet_sequence
+        self.packet_sequence += 1
+
         self.output_queue.put(packet)
 
 

--- a/viewsb/frontends/qt.py
+++ b/viewsb/frontends/qt.py
@@ -356,15 +356,16 @@ class QtFrontend(ViewSBFrontend):
     # So, Qt's tree widgets require that column 0 have the expand arrow, but you _can_ change
     # where column 0 is displayed.
     # We want the summary column to have the expand arrow, so we'll swap it
-    # with the timestamp column in __init__().
-    COLUMN_TIMESTAMP = 5
-    COLUMN_DEVICE    = 1
-    COLUMN_ENDPOINT  = 2
-    COLUMN_DIRECTION = 3
-    COLUMN_LENGTH    = 4
+    # with the sequence column in __init__().
+    COLUMN_SEQUENCE  = 6
+    COLUMN_TIMESTAMP = 1
+    COLUMN_DEVICE    = 2
+    COLUMN_ENDPOINT  = 3
+    COLUMN_DIRECTION = 4
+    COLUMN_LENGTH    = 5
     COLUMN_SUMMARY   = 0
-    COLUMN_STATUS    = 6
-    COLUMN_DATA      = 7
+    COLUMN_STATUS    = 7
+    COLUMN_DATA      = 8
 
 
     @staticmethod
@@ -406,11 +407,12 @@ class QtFrontend(ViewSBFrontend):
 
             return self._stringify_list([
                 viewsb_packet.summarize(),
+                viewsb_packet.timestamp,
                 viewsb_packet.device_address,
                 viewsb_packet.endpoint_number,
                 direction,
                 length,
-                viewsb_packet.timestamp,
+                viewsb_packet.sequence,
                 viewsb_packet.summarize_status(),
                 viewsb_packet.summarize_data()
                 ]) + [viewsb_packet]
@@ -470,7 +472,7 @@ class QtFrontend(ViewSBFrontend):
         self.window = self.loader.load(self.ui_file) # type: QMainWindow
 
         # Swap columns 0 and 5 to put the expand arrow on the summary column.
-        self.window.usb_tree_widget.header().swapSections(0, 5)
+        self.window.usb_tree_widget.header().swapSections(self.COLUMN_SUMMARY, self.COLUMN_SEQUENCE)
 
         self.window.usb_tree_widget.header().setSectionResizeMode(QtWidgets.QHeaderView.ResizeToContents)
 

--- a/viewsb/frontends/qt.ui
+++ b/viewsb/frontends/qt.ui
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-This file is part of ViewSB
--->
 <ui version="4.0">
  <class>MainWindow</class>
  <widget class="QMainWindow" name="MainWindow">
@@ -48,11 +45,16 @@ This file is part of ViewSB
        <bool>false</bool>
       </property>
       <property name="columnCount">
-       <number>8</number>
+       <number>9</number>
       </property>
       <column>
        <property name="text">
         <string>summary</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>timestamp</string>
        </property>
       </column>
       <column>
@@ -77,7 +79,7 @@ This file is part of ViewSB
       </column>
       <column>
        <property name="text">
-        <string>timestamp</string>
+        <string>packet#</string>
        </property>
       </column>
       <column>

--- a/viewsb/packet.py
+++ b/viewsb/packet.py
@@ -757,7 +757,7 @@ class USBSetupTransfer(USBSetupTransaction):
 class USBControlTransfer(USBTransfer):
     """ Class representing a USB control transfer. """
 
-    FIELDS = {'sequence', 'request_type', 'recipient', 'request_number', 'value', 'index', 'request_length', 'stalled'}
+    FIELDS = {'request_type', 'recipient', 'request_number', 'value', 'index', 'request_length', 'stalled'}
 
 
     @classmethod
@@ -766,7 +766,7 @@ class USBControlTransfer(USBTransfer):
 
         fields = {}
 
-        additional_fields = ('timestamp', 'endpoint_number', 'device_address', 'recipient')
+        additional_fields = ('sequence', 'timestamp', 'endpoint_number', 'device_address', 'recipient')
         fields_to_copy_from_setup = cls.FIELDS.union(additional_fields)
 
         # Copy each of our local fields from the Setup transaction.

--- a/viewsb/packet.py
+++ b/viewsb/packet.py
@@ -18,8 +18,6 @@ from usb_protocol.types import USBDirection, USBRequestType, USBRequestRecipient
 # XXX Temporary hack for __repr__.
 print_depth = 0
 
-
-
 class ViewSBStatus(Flag):
     """ Enumeration representing USB packet statuses. """
 
@@ -45,8 +43,9 @@ class ViewSBPacket:
 
     # The fields specific to this class. These are usually accessed using get_fields, which returns
     # the fields defined in the current or any parent class.
-    FIELDS = {'timestamp', 'bus_number', 'device_address', 'endpoint_number', 'direction', 'status', 'style',
-        'data', 'summary', 'data_summary', 'subordinate_packets'}
+    FIELDS = {'sequence', 'timestamp', 'bus_number', 'device_address', 'endpoint_number',
+        'direction', 'status', 'style', 'data', 'summary', 'data_summary',
+        'subordinate_packets'}
 
     # Data format. If a subclass overrides this with a construct Struct or BitStruct, that class
     # can call `parse_data` to automatically parse its data payload.
@@ -179,6 +178,7 @@ class ViewSBPacket:
         Strings can use prompt_toolkit style format specifications.
 
         Keys included:
+            sequence -- Sequential number of packet acquired
             timestamp -- The number of microseconds into the capture at which the given packet occurred.
             length -- The total length of the given packet, in bytes, or None if not applicable.
             device_address -- The address of the relevant USB device, or None if not applicable.
@@ -193,6 +193,7 @@ class ViewSBPacket:
         """
 
         return {
+            'sequence':        self.sequence,
             'timestamp':       self.timestamp,
             'length':          len(self.data) if self.data is not None else None,
             'bus_number':      self.bus_number,
@@ -756,7 +757,7 @@ class USBSetupTransfer(USBSetupTransaction):
 class USBControlTransfer(USBTransfer):
     """ Class representing a USB control transfer. """
 
-    FIELDS = {'request_type', 'recipient', 'request_number', 'value', 'index', 'request_length', 'stalled'}
+    FIELDS = {'sequence', 'request_type', 'recipient', 'request_number', 'value', 'index', 'request_length', 'stalled'}
 
 
     @classmethod


### PR DESCRIPTION
This PR adds a column displaying the sequential packet number as captured. 
This provides a similar gui experience as commonly used in commercial USB analyzers and Wireshark, and allows for unambiguous comparison between ViewSB output and other tools. 

Example of the QT visualisation:
![packet 1390 viewsb-qt](https://user-images.githubusercontent.com/1499454/149670463-57093b5a-43d0-4a1f-b1fa-81af14b8aa4c.png)

Corresponding packet in Wireshark:
![packet 1390 wireshark](https://user-images.githubusercontent.com/1499454/149670472-534a2d73-bdd0-4347-a9cd-4db1fb95ee61.png)
