### PR TITLE
Transfer grouping - add option to fragment the transfers

### DIFF
--- a/viewsb/analyzer.py
+++ b/viewsb/analyzer.py
@@ -28,7 +28,7 @@ class ViewSBAnalyzer:
 
     PACKET_READ_TIMEOUT = 0.1
 
-    def __init__(self, backend, frontend, decoders=None):
+    def __init__(self, backend, frontend, decoders=None, args=None):
         """ Creates a new ViewSB worker object, which is ready to run.
 
         Args:
@@ -39,7 +39,11 @@ class ViewSBAnalyzer:
             decoders -- A list of decoder classes to be applied. If not provided, all known decoders will be attempted;
                         ViewSB decoders are intended to produce sane results with all filters enabled, so this is likely
                         what you want.
+            args     -- arguments for passing options to the analysis stack
         """
+
+        # store our arguments so decoders evaluate relevant options
+        self.args = args
 
         # The fork method is the default for Linux (and macOS prior to Python 3.8), but it's considered unsafe
         # on macOS, and it isn't available on Windows, so we'll use the spawn method for all platforms.

--- a/viewsb/commands/viewsb.py
+++ b/viewsb/commands/viewsb.py
@@ -102,6 +102,8 @@ def main():
 
     parser.arg_names.append(parser.add_argument('--include-sofs', '-S', action='store_true',
         help="Include USB start-of-frame-markers in the capture; adds a lot of load & noise.").dest)
+    parser.arg_names.append(parser.add_argument('--collate-transfers', '-C', action='store_true',
+        help="Collate USB Transfers into complete high-level transfers spanning potentially multiple low-level transfers.").dest)
     parser.arg_names.append(parser.add_argument('--list-frontends', action='store_true',
         help='List the available capture backends, then quit.').dest)
     parser.arg_names.append(parser.add_argument('--list-backends', action='store_true',
@@ -189,7 +191,8 @@ def main():
     frontend = (frontend_class, frontend_args)
 
     # Create our analyzer object.
-    analyzer = ViewSBAnalyzer(backend, frontend)
+    analyzer_args = {key: args_dict[key] for key in args_dict.keys() & parser.arg_names}
+    analyzer = ViewSBAnalyzer(backend, frontend, args=analyzer_args)
 
     # Unless we're including SOFs, filter them out.
     if not args.include_sofs:

--- a/viewsb/commands/viewsb.py
+++ b/viewsb/commands/viewsb.py
@@ -102,8 +102,8 @@ def main():
 
     parser.arg_names.append(parser.add_argument('--include-sofs', '-S', action='store_true',
         help="Include USB start-of-frame-markers in the capture; adds a lot of load & noise.").dest)
-    parser.arg_names.append(parser.add_argument('--collate-transfers', '-C', action='store_true',
-        help="Collate USB Transfers into complete high-level transfers spanning potentially multiple low-level transfers.").dest)
+    parser.arg_names.append(parser.add_argument('--fragment-transfers', type=int, default=0,
+        help="Fragment large USB Transfers after sucessfully transfered bytes (0 = unlimited).").dest)
     parser.arg_names.append(parser.add_argument('--list-frontends', action='store_true',
         help='List the available capture backends, then quit.').dest)
     parser.arg_names.append(parser.add_argument('--list-backends', action='store_true',

--- a/viewsb/decoders/grouping.py
+++ b/viewsb/decoders/grouping.py
@@ -9,6 +9,7 @@ This file is part of ViewSB
 
 import collections
 from datetime import timedelta
+from construct import StreamError
 
 from usb_protocol.types import USBDirection, USBPacketID
 

--- a/viewsb/packet.py
+++ b/viewsb/packet.py
@@ -632,7 +632,7 @@ class USBDataTransfer(USBTransaction, USBTransfer):
 
                 # Append the data of all transactions that actually have data to the data of the overall transfer.
                 if isinstance(packet, USBDataTransaction):
-                    if packet.data and packet.handshake == USBPacketID.ACK:
+                    if packet.data and (packet.handshake in (USBPacketID.ACK, USBPacketID.NYET)):
                         self.data.extend(packet.data)
 
         # TODO: validate PID sequence


### PR DESCRIPTION
This PR improves the grouping of USB transfers so the data visualization can optionally support scenarios where the transfer can be extremely long or in case of streaming without an ending; resulting in packets being invisible since these are still stuck in the analysis queue.

A new command-line option has been added to force the Transfers Grouper to fragment the transfer once a specified number of bytes have been successfully transferred. Default is to not fragment, i.e. keep the original behavior. 

Example of analysis output for a streaming device with "--fragment-transfers 4096" option: 
![image](https://user-images.githubusercontent.com/1499454/151669031-ba3500a3-386c-4dab-a87d-60ebbcaaccd2.png)

This PR Fixes #86 -- the issue contains some further details that led to this PR.
