### PR TITLE
Typo: swap descriptions of the '--list-{front,back}ends' arguments.

### DIFF
--- a/viewsb/commands/viewsb.py
+++ b/viewsb/commands/viewsb.py
@@ -102,9 +102,9 @@ def main():
 
     parser.arg_names.append(parser.add_argument('--include-sofs', '-S', action='store_true',
         help="Include USB start-of-frame-markers in the capture; adds a lot of load & noise.").dest)
-    parser.arg_names.append(parser.add_argument('--list-frontends', action='store_true',
-        help='List the available capture backends, then quit.').dest)
     parser.arg_names.append(parser.add_argument('--list-backends', action='store_true',
+        help='List the available capture backends, then quit.').dest)
+    parser.arg_names.append(parser.add_argument('--list-frontends', action='store_true',
         help='List the available UI frontends, then quit.').dest)
 
 


### PR DESCRIPTION
Hi there,
while trying out ViewSB, I noticed the two descriptions for command-line arguments `--list-frontends` and `--list-backends` were swapped and put them back in the right order.

I know it's a trivial pull request, but I hope it helps anyway.

Cheers